### PR TITLE
Added option to customize placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ Option                | Default       | Version | Description
 `callback`            | -             | v0.0.5  | any valid function as callback. By default internal callback is set and just pan the map to found position
 `autocomplete_options`| {}            | v0.0.5  | default options for google autocomplete
 `collapsed_mode`      | `false`:bool  | v0.0.6  | if set to true, then just click-able icon will be displayed
+`placeholder`         | `null`:string | v0.0.7  | custom placeholder for input text

--- a/src/js/leaflet-gplaces-autocomplete.js
+++ b/src/js/leaflet-gplaces-autocomplete.js
@@ -6,6 +6,7 @@
             position: "topright",
             prepend: true,
             collapsed_mode: false,
+            placeholder: null,
             autocomplete_options: {}
         },
 
@@ -32,6 +33,10 @@
             var searchWrapper = L.DomUtil.create("div", "leaflet-gac-wrapper");
             this.searchBox = L.DomUtil.create("input", "leaflet-gac-control");
             this.autocomplete = new google.maps.places.Autocomplete(this.searchBox, this.options.autocomplete_options);
+
+            if (this.options.placeholder) {
+                this.searchBox.setAttribute("placeholder", this.options.placeholder)
+            }
 
             // if collapse mode set - create icon and register events
             if (this.options.collapsed_mode) {


### PR DESCRIPTION
By default placeholder is set and localized by Google Maps, but there is an option to customize it.

See [Docs > Customize the placeholder text for Autocomplete](https://developers.google.com/maps/documentation/javascript/places-autocomplete#placeholder_text)

usage:

```js
new L.Control.GPlaceAutocomplete({
    placeholder: 'Zadejte místo které chcete vyhledat'
}).addTo(map)
```
